### PR TITLE
fix: remove notebook-dir flag

### DIFF
--- a/scripts/es-jupyter-nb.sh
+++ b/scripts/es-jupyter-nb.sh
@@ -18,7 +18,7 @@ fi
 MODE=$1
 
 # Define the command to run Jupyter notebook
-CMD="jupyter-notebook --port 8888 --no-browser --ip=0.0.0.0 --notebook-dir=$HOME/"
+CMD="jupyter-notebook --port 8888 --no-browser --ip=0.0.0.0"
 
 # Define the job name from second argument
 NAME=$2


### PR DESCRIPTION
This flag just leads to unexpected behaviour like not finding local packages when importing using dot-notation